### PR TITLE
Enable CodeQL security scanning

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -79,9 +79,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    # Skip this job if CodeQL is not yet enabled on the repository
-    # Remove this 'if' condition once code scanning is enabled in the repository settings
-    if: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -100,8 +97,8 @@ jobs:
   # Build job that runs after all tests and security checks have passed
   build:
     name: Build
-    # Only require the jobs that are actually running (not skipped)
-    needs: [test, security-scan]
+    # Require all security jobs to pass before building
+    needs: [test, security-scan, codeql-analysis]
     runs-on: ubuntu-latest
     steps:
     - name: Check out code


### PR DESCRIPTION
This PR enables the CodeQL security scanning job by:

1. Removing the `if: false` condition that was skipping the CodeQL analysis job
2. Updating the build job's dependencies to include `codeql-analysis` in the `needs` array

These changes will enhance the security of the codebase by enabling static code analysis via CodeQL, which can detect security vulnerabilities and coding issues.

Note: For CodeQL to work properly, code scanning needs to be enabled in the repository settings.