### PR TITLE
fix: use golangci-lint v1.55.2 for Go 1.24 compatibility and enable manual workflow runs

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
       - name: Run golangci-lint
         run: golangci-lint run ./...

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 0 * * 0' # Run at midnight every Sunday
+  workflow_dispatch:
 
 jobs:
   # Basic CI testing job


### PR DESCRIPTION
- Downgrade golangci-lint to v1.55.2 for compatibility with Go 1.24.x
- Add workflow_dispatch to allow manual runs from the GitHub UI
- No other changes

This should resolve the CI linter failure and allow manual pipeline runs.