### PR TITLE
Release v0.2.0

### DIFF
--- a/.changelog/archive/v0.2.0/001_refactor_to_mathreleaser.txt
+++ b/.changelog/archive/v0.2.0/001_refactor_to_mathreleaser.txt
@@ -1,0 +1,5 @@
+# Changelog Entry for Refactoring from gorelease to mathreleaser
+
+release-note:enhancement
+Refactored project name from 'gorelease' to 'mathreleaser' to better reflect the mathematical operations performed by the application. 
+This change includes updating all references in the codebase, Makefile, GitHub workflows, and documentation.

--- a/.changelog/archive/v0.2.0/pr-13.txt
+++ b/.changelog/archive/v0.2.0/pr-13.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added PR changelog enforcement system that requires every PR to have a matching changelog entry
+```

--- a/.changelog/archive/v0.2.0/pr-14.txt
+++ b/.changelog/archive/v0.2.0/pr-14.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Renamed package from gorelease to mathreleaser to better reflect its mathematical operations
+```

--- a/.changelog/archive/v0.2.0/pr-16.txt
+++ b/.changelog/archive/v0.2.0/pr-16.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Removed obsolete gorelease folder after renaming project to mathreleaser
+```

--- a/.changelog/archive/v0.2.0/pr-17.txt
+++ b/.changelog/archive/v0.2.0/pr-17.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ready
+```

--- a/.changelog/archive/v0.2.0/refactor-mathreleaser.txt
+++ b/.changelog/archive/v0.2.0/refactor-mathreleaser.txt
@@ -1,0 +1,3 @@
+type: enhancement
+title: Refactored project from gorelease to mathreleaser
+description: Renamed binary and all related references from gorelease to mathreleaser to better reflect the mathematical nature of the application.

--- a/GITHUB_RELEASE_NOTES.md
+++ b/GITHUB_RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-# Release Notes for v0.1.0
+# Release Notes for v0.2.0
 
-f301fe7a Added basic calculator functionality with Add, Subtract, Multiply, and Divide operations. (PR #001)
-97460896 Improved error handling for division by zero. (PR #001)
-a572c3e7 Updated Go module dependencies to latest versions. (PR #001)
+6d481216 Added PR changelog enforcement system that requires every PR to have a matching changelog entry (PR #pr-13)
+f52c2e3f Renamed package from gorelease to mathreleaser to better reflect its mathematical operations (PR #pr-14)
+3512a2a2 Removed obsolete gorelease folder after renaming project to mathreleaser (PR #pr-16)
+d24d4237 ready (PR #pr-17)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 // Version variables. These will be populated at build time.
 var (
 	// Version is the current version of the application.
-	Version = "0.1.0"
+	Version = "0.2.0"
 
 	// GitCommit is the git commit hash.
 	GitCommit = "unknown"

--- a/release-notes/v0.2.0/RELEASE_NOTES.adoc
+++ b/release-notes/v0.2.0/RELEASE_NOTES.adoc
@@ -1,0 +1,17 @@
+= Release Notes for v0.2.0
+:toc:
+:toclevels: 3
+:sectnums:
+
+Release Date: 2025-07-21
+
+== FEATURES
+* Added PR changelog enforcement system that requires every PR to have a matching changelog entry
+
+
+== ENHANCEMENTS
+* Renamed package from gorelease to mathreleaser to better reflect its mathematical operations
+* Removed obsolete gorelease folder after renaming project to mathreleaser
+* ready
+
+


### PR DESCRIPTION
This PR updates the version to v0.2.0 and prepares for release.

### Changes included in this release:
- Added PR changelog enforcement system
- Renamed package from gorelease to mathreleaser
- Removed obsolete gorelease folder after renaming project
- Ready for release

### Checklist:
- [x] Version updated in code
- [x] Release notes generated
- [x] Changelog entries archived
- [x] Tests passing