### PR TITLE
feat(calculator): add tan function and tests

### DIFF
--- a/.changelog/pr-27.txt
+++ b/.changelog/pr-27.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added feature: feat(calculator): add tan function and tests CDI-000
+```

--- a/pkg/calculator/calculator.go
+++ b/pkg/calculator/calculator.go
@@ -53,3 +53,8 @@ func Sin(a float64) float64 {
 func Cos(a float64) float64 {
 	return math.Cos(a)
 }
+
+// Tan returns the tangent of an angle (in radians).
+func Tan(a float64) float64 {
+	return math.Tan(a)
+}

--- a/pkg/calculator/calculator_test.go
+++ b/pkg/calculator/calculator_test.go
@@ -196,3 +196,26 @@ func TestCos(t *testing.T) {
 		})
 	}
 }
+
+func TestTan(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{"zero", 0, 0},
+		{"pi/4", 0.7853981633974483, 1},
+		{"-pi/4", -0.7853981633974483, -1},
+	}
+
+	const epsilon = 1e-9
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tan(tt.input)
+			if diff := got - tt.expected; diff < -epsilon || diff > epsilon {
+				t.Errorf("Tan(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a tan function to the calculator package, including table-driven tests. Follows Go style and repository contribution guidelines.