### PR TITLE
Add GitHub Action workflow for automatic releases

### DIFF
--- a/.changelog/pr-32.txt
+++ b/.changelog/pr-32.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added feature: Add GitHub Action workflow for automatic releases CDI-000
+```

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,39 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Get tag name
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Check if release notes exist
+        id: check_files
+        run: |
+          if [ -f "release-notes/${{ steps.tag.outputs.tag }}/GITHUB_RELEASE.md" ]; then
+            echo "release_notes_exist=true" >> $GITHUB_OUTPUT
+          else
+            echo "release_notes_exist=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "Release ${{ steps.tag.outputs.tag }}"
+          body_path: ${{ steps.check_files.outputs.release_notes_exist == 'true' && format('release-notes/{0}/GITHUB_RELEASE.md', steps.tag.outputs.tag) || '' }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically creates GitHub releases when a new tag is pushed to the repository. The workflow:

1. Triggers when a tag is pushed with a pattern `v*`
2. Checks if release notes exist in the expected location (`release-notes/{tag}/GITHUB_RELEASE.md`)
3. Creates a GitHub release with the content from the release notes file

This eliminates the need to manually create GitHub releases after creating and pushing a tag.

You can use this workflow to create a release for v0.5.0 by re-pushing the tag:
```bash
git tag -d v0.5.0
git push --delete origin v0.5.0
git tag -a v0.5.0 -m "Release v0.5.0" fb632fcc852e0615ff35ed5e9fb1d9030d7f00c4
git push origin v0.5.0
```