### PR TITLE
Fix: Add Go binary builds to GitHub releases

### DIFF
--- a/.changelog/pr-35.txt
+++ b/.changelog/pr-35.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed issue: Fix: Add Go binary builds to GitHub releases CDI-000
+```

--- a/.changelog/pr-fix-binaries.txt
+++ b/.changelog/pr-fix-binaries.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed issue: Add Go binary builds to GitHub releases CDI-123
+```

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,20 @@ jobs:
         id: tag
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Build Go binaries
+        run: make build-all
+      
+      - name: Create checksums
+        run: |
+          mkdir -p dist
+          cp bin/* dist/
+          cd dist && find . -type f -name "mathreleaser*" | xargs shasum -a 256 > checksums.txt
+
       - name: Check if release notes exist
         id: check_files
         run: |
@@ -30,10 +44,11 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
           name: "Release ${{ steps.tag.outputs.tag }}"
-          body_path: ${{ steps.check_files.outputs.release_notes_exist == 'true' && format('release-notes/{0}/GITHUB_RELEASE.md', steps.tag.outputs.tag) || '' }}
+          bodyFile: ${{ steps.check_files.outputs.release_notes_exist == 'true' && format('release-notes/{0}/GITHUB_RELEASE.md', steps.tag.outputs.tag) || '' }}
+          artifacts: "dist/*"
           draft: false
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes an issue where v0.7.0 and later releases do not include Go binaries, while v0.5.0 did include them.

## Changes
- Updated the GitHub Actions workflow `create-release.yml` to build Go binaries when a new tag is pushed
- Added steps to attach built binaries to the GitHub Release
- Created checksums file for verification

This ensures that all future releases will automatically include the Go binaries.

Fixes: CDI-123