### PR TITLE
Release: Bump version to v0.7.1

### DIFF
--- a/.changelog/pr-v0.7.1.txt
+++ b/.changelog/pr-v0.7.1.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed issue: Add Go binary builds to GitHub releases CDI-123
+```

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Version is the current version of the application.
-	Version = "0.7.0"
+	Version = "0.7.1"
 
 	// GitCommit is the git commit hash.
 	GitCommit = "unknown"


### PR DESCRIPTION
This PR bumps the version to v0.7.1 for a patch release that includes the fix for adding Go binaries to GitHub releases.

## Changes
- Bumped version from 0.7.0 to 0.7.1
- Added changelog entry

This patch release will ensure that all future releases include Go binaries.

Relates to: CDI-123