### PR TITLE
Fix: Update go.mod with valid Go version format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/PingDavidR/go-release-test
 
-go 1.24.5
+go 1.20


### PR DESCRIPTION
This PR fixes the Go version format in go.mod.

## Issue
The current go.mod file specifies Go version as `1.24.5`, which is an invalid format. Go versions should be specified as major.minor (e.g., `1.20`).

## Changes
- Updated go.mod to use Go 1.20, which matches the version used in the GitHub workflow
- This will fix the release workflow that's currently failing with: `invalid go version '1.24.5': must match format 1.23`