### PR TITLE
Release: Bump version to v0.7.2

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Version is the current version of the application.
-	Version = "0.7.1"
+	Version = "0.7.2"
 
 	// GitCommit is the git commit hash.
 	GitCommit = "unknown"


### PR DESCRIPTION
This PR bumps the version to v0.7.2 for a new release.

This release will include the Go version format fix which should allow the release workflow to build and attach Go binaries to the GitHub release.