### PR TITLE
Fix redundant shell script checks

### DIFF
--- a/.changelog/pr-41.txt
+++ b/.changelog/pr-41.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed issue: Fix redundant shell script checks CDI-000
+```

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,9 @@ full-check: quick-check gosec govulncheck test
 
 # Developer check - run before submitting PR
 .PHONY: devcheck
-devcheck: fmt vet lint lint-all-shell
+devcheck: fmt-go vet lint-go
+	@echo "Running shell script checks once..."
+	./scripts/check-scripts.sh
 	@echo "✅ All developer checks passed! Ready to submit PR."
 
 # Check scripts with shellcheck

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -9,11 +9,11 @@ set -eo pipefail
 
 # Find all shell scripts in the repository (files with .sh extension and files with shebang line)
 find_scripts() {
-  # Find files with .sh extension
-  find . -name "*.sh" -type f | sort
-
-  # Find files with shebang line starting with #!/bin/bash, #!/usr/bin/env bash, or #!/bin/sh
-  find . -type f ! -path "*/\.*" ! -path "*/vendor/*" ! -path "*/node_modules/*" -perm +111 -exec grep -l '^\#\!/bin/bash\|^\#\!/usr/bin/env bash\|^\#\!/bin/sh' {} \; 2>/dev/null | sort -u || true
+  # Find files with .sh extension and files with bash shebang line, and deduplicate the results
+  { 
+    find . -name "*.sh" -type f
+    find . -type f ! -path "*/\.*" ! -path "*/vendor/*" ! -path "*/node_modules/*" -perm +111 -exec grep -l '^\#\!/bin/bash\|^\#\!/usr/bin/env bash\|^\#\!/bin/sh' {} \; 2>/dev/null || true
+  } | sort -u
 }
 
 # Check if shellcheck is installed

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 # Find all shell scripts in the repository (files with .sh extension and files with shebang line)
 find_scripts() {
   # Find files with .sh extension and files with bash shebang line, and deduplicate the results
-  { 
+  {
     find . -name "*.sh" -type f
     find . -type f ! -path "*/\.*" ! -path "*/vendor/*" ! -path "*/node_modules/*" -perm +111 -exec grep -l '^\#\!/bin/bash\|^\#\!/usr/bin/env bash\|^\#\!/bin/sh' {} \; 2>/dev/null || true
   } | sort -u


### PR DESCRIPTION
This PR addresses redundant shell script checks in the development workflow in two ways:

1. **Makefile optimization:** Modified the `devcheck` target to avoid redundant calls to shell script checking tools
   - Removed redundancy between `fmt`, `lint`, and `lint-all-shell` targets
   - Now explicitly calls the shell script checker only once

2. **Shell script finder enhancement:** Improved the `find_scripts()` function in `check-scripts.sh`
   - Now properly deduplicates script detection
   - Combines both file finding methods (`.sh` extension and shebang) into a single pipe
   - Eliminates duplicate reporting in the output

These changes make the development workflow more efficient and produce cleaner output when running `make devcheck`.