### PR TITLE
feat: add CLI support for power, sqrt, sin, and cos operations

### DIFF
--- a/.changelog/pr-42.txt
+++ b/.changelog/pr-42.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added feature: feat: add CLI support for power, sqrt, sin, and cos operations CDI-000
+```


### PR DESCRIPTION
This PR adds support for the following operations to the mathreleaser CLI:
- power
- sqrt
- sin
- cos

Argument handling and usage messages have been updated accordingly.